### PR TITLE
Refactor testFindOvershadowedBy test case to improve readability

### DIFF
--- a/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
+++ b/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java
@@ -123,45 +123,33 @@ public class OvershadowableManagerTest
   }
 
   @Test
-  public void testFindOvershadowedBy()
+  public void testFindOvershadowedByOvershadowed()
   {
-    final List<PartitionChunk<OvershadowableInteger>> expectedOvershadowedChunks = new ArrayList<>();
-
-    // All chunks except the last one are in the overshadowed state
-    PartitionChunk<OvershadowableInteger> chunk = newNonRootChunk(0, 2, 1, 1);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(0, 3, 2, 1);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(0, 5, 3, 1);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(5, 8, 1, 1);
-    expectedOvershadowedChunks.add(chunk);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(8, 11, 2, 1);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(5, 11, 3, 1);
-    manager.addChunk(chunk);
-    chunk = newNonRootChunk(0, 12, 5, 1);
-    manager.addChunk(chunk);
+    setupFindOvershadowedBy();
 
     List<AtomicUpdateGroup<OvershadowableInteger>> overshadowedGroups = manager.findOvershadowedBy(
-        RootPartitionRange.of(2, 10),
-        (short) 10,
-        State.OVERSHADOWED
+            RootPartitionRange.of(2, 10),
+            (short) 10,
+            State.OVERSHADOWED
     );
     Assert.assertEquals(
-        expectedOvershadowedChunks.stream().map(AtomicUpdateGroup::new).collect(Collectors.toList()),
-        overshadowedGroups
+            expectedOvershadowedChunks.stream().map(AtomicUpdateGroup::new).collect(Collectors.toList()),
+            overshadowedGroups
     );
+  }
 
-    overshadowedGroups = manager.findOvershadowedBy(
-        RootPartitionRange.of(2, 10),
-        (short) 10,
-        State.VISIBLE
+  @Test
+  public void testFindOvershadowedByVisible()
+  {
+    setupFindOvershadowedBy();
+    List<AtomicUpdateGroup<OvershadowableInteger>> overshadowedGroups = manager.findOvershadowedBy(
+            RootPartitionRange.of(2, 10),
+            (short) 10,
+            State.VISIBLE
     );
     Assert.assertEquals(
-        Collections.emptyList(),
-        overshadowedGroups
+            Collections.emptyList(),
+            overshadowedGroups
     );
   }
 
@@ -1104,5 +1092,25 @@ public class OvershadowableManagerTest
   private int nextNonRootPartitionId()
   {
     return nextNonRootPartitionId++;
+  }
+
+  public void setupFindOvershadowedBy()
+  {
+    // All chunks except the last one are in the overshadowed state
+    PartitionChunk<OvershadowableInteger> chunk = newNonRootChunk(0, 2, 1, 1);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(0, 3, 2, 1);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(0, 5, 3, 1);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(5, 8, 1, 1);
+    expectedOvershadowedChunks.add(chunk);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(8, 11, 2, 1);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(5, 11, 3, 1);
+    manager.addChunk(chunk);
+    chunk = newNonRootChunk(0, 12, 5, 1);
+    manager.addChunk(chunk);
   }
 }


### PR DESCRIPTION

<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->

This pull request refactors the test case [testFindOvershadowedBy](https://github.com/apache/druid/tree/master/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java#L126) in test class OvershadowableManagerTest. Currently, this test case combines 2 different test scenarios for the Zookeeper port initialization. The refactoring breaks this test case down into 2 separate test cases, each of which focuses on one scenario. This will help developers to  test more the potential issues in one CI\CD cycle.

<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<hr>

##### Motivation

The original test case use the one long arrangement to test two different cases for the findOvershadowedBy() method, by extracting the arrangement as one setup method in the class and splitting the test case to two unit test cases with specific name, the readability of the test case is improved. Also, this will help the developer to locate more issue in one CI/CD cycle.

##### Key changed/added classes in this PR
- Replace the [testFindOvershadowedBy](https://github.com/apache/druid/tree/master/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java#L126) test case with 2 unit test, each unit test case is named based on the test target and its specific action or parameter in the testing:
  - [testFindOvershadowedByOvershadowed](https://github.com/Codegass/druid/tree/refactor-testfindovershadowedby/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java#126)
  - [testFindOvershadowedByVisible](https://github.com/Codegass/druid/tree/refactor-testfindovershadowedby/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java#L142)
- Extract the test arrangement section as [setupFindOvershadowedBy](https://github.com/Codegass/druid/tree/refactor-testfindovershadowedby/core/src/test/java/org/apache/druid/timeline/partition/OvershadowableManagerTest.java#L1097) method.
<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:
- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
